### PR TITLE
Adjust STATIC_URL to fix MIME type resolvement

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -245,7 +245,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STATIC_ROOT = os.path.normpath(join(os.path.dirname(BASE_DIR), "static"))
 
 # Default primary key field type


### PR DESCRIPTION
This is a longshot, but after checking all projects and K8s configs, this was the only major difference (besides running Django 5.x, and the others Django 4.x).