### PR TITLE
Add superuser script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker network create zwd_network
 docker-compose -f docker-compose.local.yml build
 ```
 
-### Starting backend
+### Starting the backend
 
 Run the following to start the backend:
 
@@ -37,6 +37,13 @@ Run the following command to either create the user, or make the existing one a 
 
 ```bash
 sh bin/setup_superuser.sh <email>
+```
+
+### Using local development authentication
+To run the project with local Django authentication instead of OpenID Connect (OIDC), create a `.local.env` file with:
+
+```bash
+LOCAL_DEVELOPMENT_AUTHENTICATION=False
 ```
 
 ### Django admin

--- a/README.md
+++ b/README.md
@@ -12,23 +12,41 @@ Make sure you have Docker installed locally:
 
 These steps are necessary to make sure all configurations are set up correctly so that you can get the project running correctly.
 
-First, make sure you have built the project and executed the database migrations:
+### Creating networks & build container
+
+First, create a network and build the project:
 
 ```bash
 docker network create zwd_network
 docker-compose -f docker-compose.local.yml build
 ```
 
-Start ZWD backend:
+### Starting backend
+
+Run the following to start the backend:
 
 ```bash
 docker-compose -f docker-compose.local.yml up
 ```
 
+### Creating a superuser
+
+For accessing the Django admin during local development you'll have to become a `superuser`. This user should have the same `email` and `username` as the one that will be auto-created by the SSO login.
+
+Run the following command to either create the user, or make the existing one a superuser:
+
+```bash
+sh bin/setup_superuser.sh <email>
+```
+
+### Django admin
+
 Visit the Admin at http://localhost:8081/admin/
 
 
-If you want to make use of the DSO api the following vars need to be set in the .local.env file:
+### DSO API
+
+If you want to make use of the DSO API, the following vars need to be set in the `.local.env` file:
 
 ```bash
 DSO_API_URL=<url>

--- a/bin/setup_superuser.sh
+++ b/bin/setup_superuser.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Creates a superuser for the given `email` address, or updates if it already exists.
+#
+# Example usage:
+# ./bin/setup_superuser.sh user@amsterdam.nl
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <email>"
+    exit 1
+fi
+
+WEB_SERVICE_NAME="zwd-backend"
+EMAIL="$1"
+
+docker compose -f docker-compose.local.yml run -T --rm "${WEB_SERVICE_NAME}" python manage.py shell <<PY
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+email = "${EMAIL}"
+
+user, created = User.objects.get_or_create(email=email, username=email)
+
+user.is_staff = True
+user.is_superuser = True
+user.is_active = True
+
+user.save()
+
+print(f"{'Created' if created else 'Updated'} superuser for {email}")
+PY


### PR DESCRIPTION
- Same change as `top-backend`;
- Added a note about locally adding `LOCAL_DEVELOPMENT_AUTHENTICATION`.

---

Previous changes from `top-backend`:

Created a simple script which should tackle the SSO issues I had the other day when setting up projects and creating a superuser.

So this is to ensure that whatever you do first, the SSO-created user always aligns with creating or updating a superuser.

Scenarios tested:

✅ No user -> run this command (creates a superuser) -> visit the admin + loggin in via SSO;
✅ No user -> visit the frontend (which creates a user via SSO) -> run this command (upgrades to superuser) -> visit the admin;
✅ Existing user -> run this command (upgrades to super) (this is more or less the above scenario, given that the user was created via SSO and the username/email matches...)

Feedback or alternative solutions are welcome. If it looks good, we can implement it in other projects as well 👋