### PR TITLE
Refactor .local.env to .env.local with legacy docker-compose fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ celerybeat.pid
 
 # Environments
 .env.local
+.local.env
 .venv
 env/
 venv/
@@ -160,7 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-.local.env
 
 # VSCode
 .vscode/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sh bin/setup_superuser.sh <email>
 ```
 
 ### Using local development authentication
-To run the project with local Django authentication instead of OpenID Connect (OIDC), create a `.local.env` file with:
+To run the project with local Django authentication instead of OpenID Connect (OIDC), create a `.env.local` file with:
 
 ```bash
 LOCAL_DEVELOPMENT_AUTHENTICATION=False
@@ -53,7 +53,7 @@ Visit the Admin at http://localhost:8081/admin/
 
 ### DSO API
 
-If you want to make use of the DSO API, the following vars need to be set in the `.local.env` file:
+If you want to make use of the DSO API, the following vars need to be set in the `.env.local` file:
 
 ```bash
 DSO_API_URL=<url>

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -13,6 +13,8 @@ services:
       - database
     env_file:
       - path: .env
+      - path: .env.local
+        required: false
       - path: .local.env
         required: false
     command: bash -c "/app/deploy/docker-entrypoint.sh && exec python -m debugpy --listen 0.0.0.0:5678 ./manage.py runserver 0.0.0.0:8000"


### PR DESCRIPTION
Very minor change, but:

- This should follow common programming conventions a bit more;
- Also aligns other wonen projects;
- Includes a fallback for existing installations/users by optionally loading both `.env.local` and the older `.local.env` in the `docker-compose` file.